### PR TITLE
Added 60dB integration

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,4 @@
 ELEVENLABS_API_KEY=sk_xxxx
 OPENAI_API_KEY=sk-proj-xxxx
+CARTESIA_API_KEY=sk_xxxx
+SIXTYDB_API_KEY=sk_live_xxxx

--- a/list_60db_voices.py
+++ b/list_60db_voices.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import requests
+
+SIXTYDB_API_KEY = os.getenv("SIXTYDB_API_KEY")
+
+
+def list_voices():
+    if not SIXTYDB_API_KEY:
+        print("SIXTYDB_API_KEY is not set. Export it first, e.g. export SIXTYDB_API_KEY=sk_live_...")
+        sys.exit(1)
+
+    url = "https://api.60db.ai/myvoices"
+    headers = {"Authorization": f"Bearer {SIXTYDB_API_KEY}"}
+
+    response = requests.get(url, headers=headers)
+    if response.status_code != 200:
+        print(f"60db API error: {response.status_code} - {response.text}")
+        sys.exit(1)
+
+    payload = response.json()
+    voices = payload.get("data", [])
+    if not voices:
+        print("No voices found on this account.")
+        return
+
+    # Column widths
+    header = f"{'voice_id':<38}  {'gender':<7}  {'language':<8}  {'model':<12}  name"
+    print(header)
+    print("-" * len(header))
+    for v in voices:
+        labels = v.get("labels") or {}
+        print(
+            f"{v.get('voice_id', ''):<38}  "
+            f"{labels.get('gender', ''):<7}  "
+            f"{labels.get('language', ''):<8}  "
+            f"{v.get('model', ''):<12}  "
+            f"{v.get('name', '')}"
+        )
+
+    print(f"\n{len(voices)} voice(s). Copy a voice_id into main.py -> voice_sarah_id.")
+
+
+if __name__ == "__main__":
+    list_voices()

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 import json
+import base64
 import requests
 import time
 import subprocess
@@ -18,12 +19,14 @@ max_workers = 3  # cartesia default is 3. you have to upgrade to use more.
 ELEVENLABS_API_KEY = os.getenv("ELEVENLABS_API_KEY")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 CARTESIA_API_KEY = os.getenv("CARTESIA_API_KEY")
+SIXTYDB_API_KEY = os.getenv("SIXTYDB_API_KEY")
 
 def validate_api_keys():
     required_keys = {
         "ELEVENLABS_API_KEY": ELEVENLABS_API_KEY,
         "OPENAI_API_KEY": OPENAI_API_KEY,
-        "CARTESIA_API_KEY": CARTESIA_API_KEY
+        "CARTESIA_API_KEY": CARTESIA_API_KEY,
+        "SIXTYDB_API_KEY": SIXTYDB_API_KEY
     }
 
     for key_name, key_value in required_keys.items():
@@ -111,15 +114,15 @@ def generate_dialogue():
 
     return response.choices[0].message.function_call.arguments
 
-def text_to_speech_file(name: str, text: str, voice_id: str, temp_folder: str, history: list, use_cartesia: bool = False, progress: tuple = None) -> tuple:
+def text_to_speech_file(name: str, text: str, voice_id: str, temp_folder: str, history: list, provider: str = "elevenlabs", progress: tuple = None) -> tuple:
     if progress:
         current, total = progress
-        log("TTS_PROGRESS", f"Converting text to speech for voice {voice_id} ({current}/{total})...")
+        log("TTS_PROGRESS", f"Converting text to speech via {provider} for voice {voice_id} ({current}/{total})...")
     else:
-        log("TTS", f"Converting text to speech for voice {voice_id}...")
+        log("TTS", f"Converting text to speech via {provider} for voice {voice_id}...")
     start_time = time.time()
 
-    if use_cartesia:
+    if provider == "cartesia":
         # Use Cartesia API for Karan and Sarah
         url = "https://api.cartesia.ai/tts/bytes"
         headers = {
@@ -166,6 +169,41 @@ def text_to_speech_file(name: str, text: str, voice_id: str, temp_folder: str, h
         else:
             log("TTS_ERROR", f"Cartesia API error: {response.status_code} - {response.text}")
             return None, None, 0.0  # {{ edit_3 }}
+    elif provider == "60db":
+        # Use 60db (https://api.60db.ai) for Sarah
+        url = "https://api.60db.ai/tts-synthesize"
+        headers = {
+            "Authorization": f"Bearer {SIXTYDB_API_KEY}",
+            "Content-Type": "application/json"
+        }
+        data = {
+            "text": text + " ",  # trailing space to avoid clipping the last word, same as the others
+            "voice_id": voice_id,
+            "output_format": "mp3",     # keep MP3 across all providers for consistent combining
+            "stability": 50,            # 0-100 scale; matches ElevenLabs' 0.5
+            "similarity": 75,           # 0-100 scale; matches ElevenLabs' 0.75
+            "speed": 1,
+            "enhance": True
+        }
+
+        response = requests.post(url, json=data, headers=headers)
+        if response.status_code == 200:
+            result = response.json()
+            audio_base64 = result.get("audio_base64")
+            if not result.get("success", False) or not audio_base64:
+                log("TTS_ERROR", f"60db API error: {result.get('message', 'no audio returned')}")
+                return None, None, 0.0
+            save_file_path = os.path.join(temp_folder, f"{current if progress else ''}-{name}-{uuid.uuid4()}.mp3".strip('-'))
+            with open(save_file_path, "wb") as f:
+                f.write(base64.b64decode(audio_base64))
+            generation_id = None  # 60db's TTS response carries no request/generation id
+
+            # Get duration using pydub (same as the other providers, keeps caption timestamps consistent)
+            audio = AudioSegment.from_mp3(save_file_path)
+            duration_sec = len(audio) / 1000.0
+        else:
+            log("TTS_ERROR", f"60db API error: {response.status_code} - {response.text}")
+            return None, None, 0.0
     else:
         # Use ElevenLabs for Charlie (Host)
         url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}/stream"
@@ -227,28 +265,37 @@ def main():
     log("TEMP_FOLDER", f"Created temporary folder: {temp_folder}")
 
     voice_host_id = "IKne3meq5aSn9XLyUdCD"  # Charlie pre-made voice (ElevenLabs)
-    voice_karan_id = "638efaaa-4d0c-442e-b701-3fae16aad012"  # Replace with actual Cartesia voice ID for Karan
-    voice_sarah_id = "79a125e8-cd45-4c13-8a67-188112f4dd22"  # Replace with actual Cartesia voice ID for Sarah
+    voice_karan_id = "638efaaa-4d0c-442e-b701-3fae16aad012"  # Cartesia voice ID for Karan
+    voice_sarah_id = "REPLACE_WITH_60DB_VOICE_ID"  # 60db voice ID for Sarah (from GET https://api.60db.ai/myvoices)
 
     audio_files = {}  # {{ edit_6 }}
     history_host = []
     history_karan = []
     history_sarah = []
 
+    # Per-speaker routing: (provider, voice_id, history) -> Host=ElevenLabs, Karan=Cartesia, Sarah=60db
+    voice_config = {
+        "Host":  ("elevenlabs", voice_host_id,  history_host),
+        "Karan": ("cartesia",   voice_karan_id, history_karan),
+        "Sarah": ("60db",       voice_sarah_id, history_sarah),
+    }
+
     log("DIALOGUE_PROCESS", f"Processing {len(dialogue)} dialogue lines...")
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-        future_to_index = {
-            executor.submit(
+        future_to_index = {}
+        for i, line in enumerate(dialogue):
+            provider, voice_id, history = voice_config[line['speaker']]
+            future = executor.submit(
                 text_to_speech_file,
                 line['speaker'],
                 line['text'],
-                voice_host_id if line['speaker'] == "Host" else (voice_karan_id if line['speaker'] == "Karan" else voice_sarah_id),
+                voice_id,
                 temp_folder,
-                history_host if line['speaker'] == "Host" else (history_karan if line['speaker'] == "Karan" else history_sarah),
-                False if line['speaker'] == "Host" else True,
+                history,
+                provider,
                 (i+1, len(dialogue))
-            ): i for i, line in enumerate(dialogue)
-        }
+            )
+            future_to_index[future] = i
         # Initialize list to hold transcript with timestamps
         transcript_with_timestamps = []  # {{ edit_7 }}
         current_time = 0.0  # {{ edit_8 }}

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,20 @@
 # smol notebook lm
 
-Convert text to speech using the `ElevenLabs` client. Ensure `rawtext.md` is updated, all environment keys are loaded, and outputs are available in `.mp3`, `.txt`, and `.log` formats.
+Generates an AI news podcast (and optional video) from raw text. GPT-4o writes a 3-host dialogue, which is then converted to speech using **three TTS providers** — one per host — and stitched into a single audio file. Ensure `rawtext.md` is updated, all environment keys are loaded, and outputs are available in `.mp3`, `.txt`, and `.log` formats.
 
 You can see sample output here: https://github.com/smol-ai/temp
+
+### Text-to-Speech providers
+
+Each speaker is routed to a different TTS provider (see `voice_config` in `main.py`):
+
+| Speaker | Provider | Endpoint |
+|---------|----------|----------|
+| Host (Charlie) | **ElevenLabs** | `POST https://api.elevenlabs.io/v1/text-to-speech/{voice_id}/stream` |
+| Karan | **Cartesia** | `POST https://api.cartesia.ai/tts/bytes` |
+| Sarah | **60db** | `POST https://api.60db.ai/tts-synthesize` |
+
+All three return MP3 (60db is base64-decoded from JSON), and clip durations are measured with `pydub` so caption timestamps stay consistent across providers.
 
 
 ## requirements
@@ -22,12 +34,20 @@ You can see sample output here: https://github.com/smol-ai/temp
    export ELEVENLABS_API_KEY=your_api_key
    export OPENAI_API_KEY=your_api_key
    export CARTESIA_API_KEY=your_api_key # note that this thing generates a lot of tokens. we used up 52k cahracters just developing this.
+   export SIXTYDB_API_KEY=your_api_key # 60db (https://api.60db.ai) — used for Sarah's voice
    ```
 
 3. **Update `rawtext.md`:**
    - Add or modify the text you want to convert to speech.
 
-4. **Run the Script:**
+4. **Set Sarah's 60db voice ID:**
+   - List the voices on your 60db account (calls `GET https://api.60db.ai/myvoices`):
+     ```bash
+     python list_60db_voices.py
+     ```
+   - Copy a `voice_id` from the output into `main.py` → `voice_sarah_id`.
+
+5. **Run the Script:**
    ```bash
    python main.py
    ```
@@ -73,6 +93,15 @@ To generate a video from the audio and transcript, you can use the `video.py` sc
 - **Audio:** `.mp3` files
 - **Transcript:** `.txt` files
 - **Logs:** `.log` files
+
+### 60db integration (what's new)
+
+- **Sarah's voice now uses 60db** via `POST /tts-synthesize` (base64 MP3 decoded to disk). Host stays on ElevenLabs, Karan on Cartesia.
+- `text_to_speech_file()` switched from a `use_cartesia` flag to a `provider` selector (`elevenlabs` / `cartesia` / `60db`), with routing driven by a `voice_config` dict in `main()`.
+- New `SIXTYDB_API_KEY` env var (added to `.env` and validation).
+- New `list_60db_voices.py` helper to fetch your voice IDs (`GET /myvoices`).
+
+> **Reminder:** 60db's TTS response carries no generation/history ID, so Sarah's lines are synthesized independently — there's no cross-line voice continuity (same as Cartesia for Karan). This is expected.
 
 ### Examples
 


### PR DESCRIPTION
Added a "60db integration (what's new)" section to the README with a short description and the reminder. It covers:

  - Sarah → 60db via POST /tts-synthesize (base64 MP3 decoded to disk); Host stays ElevenLabs, Karan stays Cartesia.
  - text_to_speech_file() now uses a provider selector instead of use_cartesia, routed by voice_config.
  - New SIXTYDB_API_KEY env var.
  - New list_60db_voices.py helper.

  And the reminder :

  ▎ Reminder: 60db's TTS response carries no generation/history ID, so Sarah's lines are synthesized independently — no cross-line  
  ▎ voice continuity (same as Cartesia for Karan). This is expected.